### PR TITLE
fix default doc name

### DIFF
--- a/assets/js/excalidraw.tsx
+++ b/assets/js/excalidraw.tsx
@@ -20,7 +20,7 @@ type ExcalidrawImperativeAPI = Parameters<
 const socket = new Socket("/socket");
 socket.connect();
 const ydoc = new Y.Doc();
-const docname = `excalidraw:${new URLSearchParams(window.location.search).get("docname") ?? "exalidraw"}`;
+const docname = `excalidraw:${new URLSearchParams(window.location.search).get("docname") ?? "excalidraw"}`;
 
 const provider = new PhoenixChannelProvider(
   socket,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected the default document name from “exalidraw” to “excalidraw” when no name is provided.
  - Ensures consistent naming for new sessions and shared links started without a specified document name.
  - Note: Documents created previously under the misspelled default may not auto-associate with the new default name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->