### PR TITLE
add awareness throttle

### DIFF
--- a/lib/y_phoenix_web/channels/doc_server.ex
+++ b/lib/y_phoenix_web/channels/doc_server.ex
@@ -214,6 +214,10 @@ defmodule YPhoenixWeb.DocServer do
     topic = state.assigns.topic
     trailing_origin = resolve_pending_origin(state.assigns.awareness_pending_origin)
 
+    if state.assigns.awareness_flush_timer_ref do
+      Process.cancel_timer(state.assigns.awareness_flush_timer_ref)
+    end
+
     state =
       assign(state, %{
         awareness_window_open: false,

--- a/lib/y_phoenix_web/channels/doc_server.ex
+++ b/lib/y_phoenix_web/channels/doc_server.ex
@@ -7,6 +7,7 @@ defmodule YPhoenixWeb.DocServer do
 
   @persistence YPhoenix.EctoPersistence
   @ttl 5_000
+  @awareness_throttle_ms 50
 
   @impl true
   def init(option, %{doc: doc} = state) do
@@ -28,7 +29,12 @@ defmodule YPhoenixWeb.DocServer do
        origin_clients_map: %{},
        user_count: user_count,
        persistance_state: persistance_state,
-       shutdown_timer_ref: nil
+       shutdown_timer_ref: nil,
+       awareness_throttle_ms: @awareness_throttle_ms,
+       awareness_window_open: false,
+       awareness_pending_clients: MapSet.new(),
+       awareness_pending_origin: :unset,
+       awareness_flush_timer_ref: nil
      })}
   end
 
@@ -71,24 +77,48 @@ defmodule YPhoenixWeb.DocServer do
         origin,
         state
       ) do
-    updated_clients = added ++ updated ++ removed
+    updated_clients = MapSet.new(added ++ updated ++ removed)
 
-    with {:ok, update} <- Awareness.encode_update(awareness, updated_clients),
-         {:ok, message} <- Sync.message_encode({:awareness, update}) do
-      broadcast_awareness_update(origin, state.assigns.topic, message)
+    state =
+      if origin do
+        monitor_and_update_origin_clients_map(state, origin, added, removed)
+      else
+        state
+      end
 
-      state =
-        if origin do
-          monitor_and_update_origin_clients_map(state, origin, added, removed)
-        else
-          state
-        end
+    if state.assigns.awareness_window_open do
+      pending_clients = MapSet.union(state.assigns.awareness_pending_clients, updated_clients)
+      pending_origin = merge_pending_origin(state.assigns.awareness_pending_origin, origin)
 
-      {:noreply, state}
+      {:noreply,
+       assign(state, %{
+         awareness_pending_clients: pending_clients,
+         awareness_pending_origin: pending_origin
+       })}
     else
-      error ->
-        Logger.log(:warning, error)
-        {:noreply, state}
+      with {:ok, update} <- Awareness.encode_update(awareness, MapSet.to_list(updated_clients)),
+           {:ok, message} <- Sync.message_encode({:awareness, update}) do
+        broadcast_awareness_update(origin, state.assigns.topic, message)
+
+        ref =
+          Process.send_after(
+            self(),
+            :flush_awareness,
+            state.assigns.awareness_throttle_ms
+          )
+
+        {:noreply,
+         assign(state, %{
+           awareness_window_open: true,
+           awareness_pending_clients: MapSet.new(),
+           awareness_pending_origin: :unset,
+           awareness_flush_timer_ref: ref
+         })}
+      else
+        error ->
+          Logger.log(:warning, error)
+          {:noreply, state}
+      end
     end
   end
 
@@ -133,7 +163,7 @@ defmodule YPhoenixWeb.DocServer do
     assign(state, %{origin_clients_map: origin_clients_map})
   end
 
-  def handle_info({:DOWN, ref, :process, pid, _reason}, state) do
+  def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
     origin_clients_map = state.assigns[:origin_clients_map] || %{}
 
     case Map.get(origin_clients_map, pid) do
@@ -158,7 +188,7 @@ defmodule YPhoenixWeb.DocServer do
     {:noreply, assign(state, :shutdown_timer_ref, nil)}
   end
 
-  def handle_info({Presence, {:leave, presence}}, state) do
+  def handle_info({Presence, {:leave, _presence}}, state) do
     user_count = state.assigns.user_count - 1
     state = assign(state, :user_count, user_count)
 
@@ -179,6 +209,36 @@ defmodule YPhoenixWeb.DocServer do
     {:noreply, state}
   end
 
+  def handle_info(:flush_awareness, state) do
+    pending_clients = MapSet.to_list(state.assigns.awareness_pending_clients)
+    topic = state.assigns.topic
+    trailing_origin = resolve_pending_origin(state.assigns.awareness_pending_origin)
+
+    state =
+      assign(state, %{
+        awareness_window_open: false,
+        awareness_pending_clients: MapSet.new(),
+        awareness_pending_origin: :unset,
+        awareness_flush_timer_ref: nil
+      })
+
+    case pending_clients do
+      [] ->
+        {:noreply, state}
+
+      _ ->
+        with {:ok, update} <- Awareness.encode_update(state.awareness, pending_clients),
+             {:ok, message} <- Sync.message_encode({:awareness, update}) do
+          broadcast_awareness_update(trailing_origin, topic, message)
+          {:noreply, state}
+        else
+          error ->
+            Logger.log(:warning, error)
+            {:noreply, state}
+        end
+    end
+  end
+
   def handle_info(:delayed_shutdown, state) do
     if state.assigns.user_count <= 0 do
       {:stop, :shutdown, state}
@@ -189,6 +249,10 @@ defmodule YPhoenixWeb.DocServer do
 
   @impl true
   def terminate(_reason, state) do
+    if state.assigns.awareness_flush_timer_ref do
+      Process.cancel_timer(state.assigns.awareness_flush_timer_ref)
+    end
+
     @persistence.unbind(
       state.assigns.persistance_state,
       state.assigns.doc_name,
@@ -199,4 +263,13 @@ defmodule YPhoenixWeb.DocServer do
 
     :ok
   end
+
+  defp merge_pending_origin(:unset, origin), do: origin
+  defp merge_pending_origin(:mixed, _origin), do: :mixed
+  defp merge_pending_origin(origin, origin), do: origin
+  defp merge_pending_origin(_origin, _other_origin), do: :mixed
+
+  defp resolve_pending_origin(:unset), do: nil
+  defp resolve_pending_origin(:mixed), do: nil
+  defp resolve_pending_origin(origin), do: origin
 end

--- a/lib/y_phoenix_web/channels/presence.ex
+++ b/lib/y_phoenix_web/channels/presence.ex
@@ -14,13 +14,13 @@ defmodule YPhoenixWeb.Presence do
   end
 
   def handle_metas(topic, %{joins: joins, leaves: leaves}, presences, state) do
-    for {user_id, presence} <- joins do
+    for {user_id, _presence} <- joins do
       user_data = %{id: user_id, metas: Map.fetch!(presences, user_id)}
       msg = {__MODULE__, {:join, user_data}}
       Phoenix.PubSub.local_broadcast(YPhoenix.PubSub, "proxy:#{topic}", msg)
     end
 
-    for {user_id, presence} <- leaves do
+    for {user_id, _presence} <- leaves do
       metas =
         case Map.fetch(presences, user_id) do
           {:ok, presence_metas} -> presence_metas

--- a/test/y_phoenix_web/channels/doc_server_test.exs
+++ b/test/y_phoenix_web/channels/doc_server_test.exs
@@ -49,7 +49,7 @@ defmodule YPhoenixWeb.DocServerTest do
         state
       )
 
-    refute_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "yjs"}, 10
+    refute_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "yjs"}, 100
 
     {:noreply, state} = YPhoenixWeb.DocServer.handle_info(:flush_awareness, state)
 
@@ -107,7 +107,7 @@ defmodule YPhoenixWeb.DocServerTest do
 
     {:noreply, _state} = YPhoenixWeb.DocServer.handle_info(:flush_awareness, state)
 
-    refute_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "yjs"}, 10
+    refute_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "yjs"}, 100
   end
 
   test "trailing awareness falls back to broadcast when pending origins are mixed" do
@@ -161,6 +161,8 @@ defmodule YPhoenixWeb.DocServerTest do
         nil,
         state
       )
+
+    refute_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "yjs"}, 20
 
     {:noreply, _state} = YPhoenixWeb.DocServer.handle_info(:flush_awareness, state)
 

--- a/test/y_phoenix_web/channels/doc_server_test.exs
+++ b/test/y_phoenix_web/channels/doc_server_test.exs
@@ -1,0 +1,169 @@
+defmodule YPhoenixWeb.DocServerTest do
+  use YPhoenixWeb.ChannelCase, async: true
+
+  alias Yex.Awareness
+  alias Yex.Doc
+  alias Yex.DocServer.State
+
+  test "awareness updates are throttled with leading and trailing broadcasts" do
+    topic = "y_doc_room:throttle_test"
+    :ok = YPhoenixWeb.Endpoint.subscribe(topic)
+
+    doc = Doc.new()
+    {:ok, awareness} = Awareness.new(doc)
+    :ok = Awareness.set_local_state(awareness, %{"name" => "alice"})
+
+    client_id = Awareness.client_id(awareness)
+
+    state =
+      %State{doc: doc, awareness: awareness, module: YPhoenixWeb.DocServer}
+      |> State.assign(%{
+        topic: topic,
+        doc_name: "throttle_test",
+        origin_clients_map: %{},
+        user_count: 1,
+        persistance_state: %{},
+        shutdown_timer_ref: nil,
+        awareness_throttle_ms: 50,
+        awareness_window_open: false,
+        awareness_pending_clients: MapSet.new(),
+        awareness_pending_origin: :unset,
+        awareness_flush_timer_ref: nil
+      })
+
+    {:noreply, state} =
+      YPhoenixWeb.DocServer.handle_awareness_update(
+        awareness,
+        %{removed: [], added: [client_id], updated: []},
+        nil,
+        state
+      )
+
+    assert_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "yjs"}
+
+    {:noreply, state} =
+      YPhoenixWeb.DocServer.handle_awareness_update(
+        awareness,
+        %{removed: [], added: [], updated: [client_id]},
+        nil,
+        state
+      )
+
+    refute_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "yjs"}, 10
+
+    {:noreply, state} = YPhoenixWeb.DocServer.handle_info(:flush_awareness, state)
+
+    assert_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "yjs"}
+
+    assert state.assigns.awareness_window_open == false
+    assert state.assigns.awareness_pending_clients == MapSet.new()
+    assert state.assigns.awareness_pending_origin == :unset
+    assert is_nil(state.assigns.awareness_flush_timer_ref)
+  end
+
+  test "trailing awareness uses origin when all pending updates share the same origin" do
+    topic = "y_doc_room:throttle_origin_same"
+    :ok = YPhoenixWeb.Endpoint.subscribe(topic)
+
+    doc = Doc.new()
+    {:ok, awareness} = Awareness.new(doc)
+    :ok = Awareness.set_local_state(awareness, %{"name" => "alice"})
+
+    client_id = Awareness.client_id(awareness)
+
+    state =
+      %State{doc: doc, awareness: awareness, module: YPhoenixWeb.DocServer}
+      |> State.assign(%{
+        topic: topic,
+        doc_name: "throttle_origin_same",
+        origin_clients_map: %{},
+        user_count: 1,
+        persistance_state: %{},
+        shutdown_timer_ref: nil,
+        awareness_throttle_ms: 50,
+        awareness_window_open: false,
+        awareness_pending_clients: MapSet.new(),
+        awareness_pending_origin: :unset,
+        awareness_flush_timer_ref: nil
+      })
+
+    {:noreply, state} =
+      YPhoenixWeb.DocServer.handle_awareness_update(
+        awareness,
+        %{removed: [], added: [client_id], updated: []},
+        nil,
+        state
+      )
+
+    assert_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "yjs"}
+
+    {:noreply, state} =
+      YPhoenixWeb.DocServer.handle_awareness_update(
+        awareness,
+        %{removed: [], added: [], updated: [client_id]},
+        self(),
+        state
+      )
+
+    {:noreply, _state} = YPhoenixWeb.DocServer.handle_info(:flush_awareness, state)
+
+    refute_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "yjs"}, 10
+  end
+
+  test "trailing awareness falls back to broadcast when pending origins are mixed" do
+    topic = "y_doc_room:throttle_origin_mixed"
+    :ok = YPhoenixWeb.Endpoint.subscribe(topic)
+
+    doc = Doc.new()
+    {:ok, awareness} = Awareness.new(doc)
+    :ok = Awareness.set_local_state(awareness, %{"name" => "alice"})
+
+    client_id = Awareness.client_id(awareness)
+
+    state =
+      %State{doc: doc, awareness: awareness, module: YPhoenixWeb.DocServer}
+      |> State.assign(%{
+        topic: topic,
+        doc_name: "throttle_origin_mixed",
+        origin_clients_map: %{},
+        user_count: 1,
+        persistance_state: %{},
+        shutdown_timer_ref: nil,
+        awareness_throttle_ms: 50,
+        awareness_window_open: false,
+        awareness_pending_clients: MapSet.new(),
+        awareness_pending_origin: :unset,
+        awareness_flush_timer_ref: nil
+      })
+
+    {:noreply, state} =
+      YPhoenixWeb.DocServer.handle_awareness_update(
+        awareness,
+        %{removed: [], added: [client_id], updated: []},
+        nil,
+        state
+      )
+
+    assert_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "yjs"}
+
+    {:noreply, state} =
+      YPhoenixWeb.DocServer.handle_awareness_update(
+        awareness,
+        %{removed: [], added: [], updated: [client_id]},
+        self(),
+        state
+      )
+
+    {:noreply, state} =
+      YPhoenixWeb.DocServer.handle_awareness_update(
+        awareness,
+        %{removed: [], added: [], updated: [client_id]},
+        nil,
+        state
+      )
+
+    {:noreply, _state} = YPhoenixWeb.DocServer.handle_info(:flush_awareness, state)
+
+    assert_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "yjs"}
+  end
+end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented delayed awareness flushes from running after server shutdown to avoid stray broadcasts

* **Refactor**
  * Batched and deduplicated awareness updates during throttle windows for fewer, consolidated broadcasts
  * Simplified presence handling internals for minor clarity

* **Tests**
  * Added tests covering awareness throttling, broadcast coalescing, and origin-handling scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->