### PR TITLE
fix: send resync instruction to clients when shared doc process resta…

### DIFF
--- a/lib/y_phoenix_web/channels/y_doc_room_channel.ex
+++ b/lib/y_phoenix_web/channels/y_doc_room_channel.ex
@@ -65,11 +65,27 @@ defmodule YPhoenixWeb.YDocRoomChannel do
 
   @impl true
   def handle_info(
-        {:DOWN, _ref, :process, _pid, _reason},
-        socket
+        {:DOWN, _ref, :process, pid, _reason},
+        %{assigns: %{doc_pid: pid, doc_name: doc_name}} = socket
       ) do
-    {:stop, {:error, "remote process crash"}, socket}
+    # Only handle :DOWN for the current doc_pid
+    topic = "y_doc_room:" <> doc_name
+    old_pid = pid
+
+    case start_shared_doc(topic, doc_name) do
+      {:ok, docpid} ->
+        Process.monitor(docpid)
+        push(socket, "yjs_resync", %{})
+        {:noreply, assign(socket, doc_pid: docpid)}
+
+      {:error, reason} ->
+        push(socket, "yjs_server_down", %{})
+        {:stop, {:error, "failed to restart shared doc: #{inspect(reason)}"}, socket}
+    end
   end
+
+  # Catch-all for unrelated :DOWNs (do nothing)
+  def handle_info({:DOWN, _ref, :process, _pid, _reason}, socket), do: {:noreply, socket}
 
   defp start_shared_doc(topic, doc_name) do
     case :syn.lookup(:doc_servers, doc_name) do

--- a/npm/y-phoenix-channel/src/y-phoenix-channel.ts
+++ b/npm/y-phoenix-channel/src/y-phoenix-channel.ts
@@ -162,6 +162,38 @@ const setupChannel = (provider: PhoenixChannelProvider, joinPush: Push) => {
         provider.channel?.push("yjs", encoding.toUint8Array(encoder).buffer);
       }
     });
+    provider.channel.on("yjs_resync", (data) => {
+      // When server is restarted, it will send "yjs_resync" message to notify clients to resync
+      const encoder = encoding.createEncoder();
+      encoding.writeVarUint(encoder, messageSync);
+      syncProtocol.writeSyncStep1(encoder, provider.doc);
+      provider.channel?.push("yjs_sync", encoding.toUint8Array(encoder).buffer);
+
+      // Also re-broadcast local awareness state, since server-side awareness is wiped on restart
+      if (provider.awareness.getLocalState() !== null) {
+        const encoderAwarenessState = encoding.createEncoder();
+        encoding.writeVarUint(encoderAwarenessState, messageAwareness);
+        encoding.writeVarUint8Array(
+          encoderAwarenessState,
+          awarenessProtocol.encodeAwarenessUpdate(provider.awareness, [
+            provider.doc.clientID,
+          ]),
+        );
+        provider.channel?.push(
+          "yjs",
+          encoding.toUint8Array(encoderAwarenessState).buffer,
+        );
+      }
+    });
+
+    provider.channel.on("yjs_server_down", () => {
+      // Server failed to restart the shared doc process. This is informational only.
+      // You may want to show a notification or handle reconnection logic here.
+      // For now, we just log it.
+      console.warn(
+        "yjs_server_down: server failed to restart shared doc process",
+      );
+    });
 
     provider.emit("status", [
       {
@@ -175,10 +207,10 @@ const setupChannel = (provider: PhoenixChannelProvider, joinPush: Push) => {
         },
       ]);
 
-        if (hasHandledJoinInCurrentCycle) {
-          return;
-        }
-        hasHandledJoinInCurrentCycle = true;
+      if (hasHandledJoinInCurrentCycle) {
+        return;
+      }
+      hasHandledJoinInCurrentCycle = true;
 
       const encoder = encoding.createEncoder();
       encoding.writeVarUint(encoder, messageSync);


### PR DESCRIPTION
…rts and add client-side resync handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Channel now automatically recovers from server process crashes instead of disconnecting users
  * Automatic data resynchronization implemented when recovery is triggered
  * Error notifications displayed when recovery fails

<!-- end of auto-generated comment: release notes by coderabbit.ai -->